### PR TITLE
getTextContent: Fix missing whitespace between text nodes.

### DIFF
--- a/read.go
+++ b/read.go
@@ -1006,7 +1006,7 @@ func getTextContent(articleContent *goquery.Selection) string {
 		if n.Type == html.TextNode {
 			nodeText := normalizeText(n.Data)
 			if nodeText != "" {
-				buf.WriteString(nodeText)
+				buf.WriteString(nodeText + " ")
 			}
 		} else if n.Parent != nil && n.Parent.DataAtom != atom.P {
 			buf.WriteString("|X|")


### PR DESCRIPTION
If the parser removes HTML tags, there is a whitespace missing between two
words, especially when there are hyperlinks involved.

See issue #6 for further information.