### PR TITLE
[WIP] Update Parse method to skip parsing URIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/sergi/go-diff v1.0.0
-	github.com/sirupsen/logrus v1.4.2
+	github.com/Sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.4
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20190520210107-018c4d40a106

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
-github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/Sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
+github.com/Sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.4 h1:S0tLZ3VOKl2Te0hpq8+ke0eSJPfCnNTPiDlsfwi1/NE=

--- a/parser.go
+++ b/parser.go
@@ -1682,11 +1682,13 @@ func (ps *Parser) Parse(input io.Reader, pageURL string) (Article, error) {
 		cleanConditionally: true,
 	}
 
-	// Parse page url
 	var err error
-	ps.documentURI, err = nurl.ParseRequestURI(pageURL)
-	if err != nil {
-		return Article{}, fmt.Errorf("failed to parse URL: %v", err)
+	// If a pageURL is passed, parse the page url
+	if pageURL != "" {
+		ps.documentURI, err = nurl.ParseRequestURI(pageURL)
+		if err != nil {
+			return Article{}, fmt.Errorf("failed to parse URL: %v", err)
+		}
 	}
 
 	// Parse input

--- a/scripts/generate-test.go
+++ b/scripts/generate-test.go
@@ -10,8 +10,8 @@ import (
 	fp "path/filepath"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	readability "github.com/go-shiori/go-readability"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/html"
 )
 

--- a/utils-common.go
+++ b/utils-common.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"golang.org/x/net/html"
 )
 


### PR DESCRIPTION
This PR introduces logic that allows parsing an input of `io.Reader` without necessarily supplying a `pageURL`. This allows some flexibility, as sometimes you might not want (or have access) to pass a `pageURL`. To bypass, simple send a zero-valued `string`.

This is still currently a WIP, as I figure out the best way to test this with the current test suite in place :)