### PR TITLE
Fix: switch from IsReadable to Check

### DIFF
--- a/cmd/go-readability/main.go
+++ b/cmd/go-readability/main.go
@@ -128,7 +128,7 @@ func getContent(srcPath string, metadataOnly bool) (string, error) {
 	tee := io.TeeReader(srcReader, buf)
 
 	// Make sure the page is readable
-	if !readability.IsReadable(tee) {
+	if !readability.Check(tee) {
 		return "", fmt.Errorf("failed to parse page: the page is not readable")
 	}
 


### PR DESCRIPTION
Commit 82cc334 replaced readability.IsReadable with readability.Check,
but the code for the cmdline program wasn't updated to reflect this.
This caused a build failure.

This commit renames that variable so that the go-readability CLI program
can be built again.