### PR TITLE
Fix: Include article tag in the check document function

### DIFF
--- a/parser-check.go
+++ b/parser-check.go
@@ -42,7 +42,7 @@ func (ps *Parser) CheckDocument(doc *html.Node) bool {
 	finder = func(node *html.Node) {
 		if node.Type == html.ElementNode {
 			tag := dom.TagName(node)
-			if tag == "p" || tag == "pre" {
+			if tag == "p" || tag == "pre" || tag == "article" {
 				if _, exist := nodeDict[node]; !exist {
 					nodeList = append(nodeList, node)
 					nodeDict[node] = struct{}{}


### PR DESCRIPTION
Try to fix https://github.com/go-shiori/go-readability/issues/26

See https://github.com/mozilla/readability/commit/1b5a66ffb8e227938777ad955bf65eb446d35805