### PR TITLE
feat: parse modified and published dates from articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ js/*
 
 # Hidden script for development
 scripts/internal/
+.DS_Store

--- a/parser_test.go
+++ b/parser_test.go
@@ -9,6 +9,7 @@ import (
 	fp "path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-shiori/dom"
 	"github.com/sergi/go-diff/diffmatchpatch"
@@ -20,12 +21,14 @@ var (
 )
 
 type ExpectedMetadata struct {
-	Title      string `json:"title,omitempty"`
-	Byline     string `json:"byline,omitempty"`
-	Excerpt    string `json:"excerpt,omitempty"`
-	Language   string `json:"language,omitempty"`
-	SiteName   string `json:"siteName,omitempty"`
-	Readerable bool   `json:"readerable"`
+	Title         string `json:"title,omitempty"`
+	Byline        string `json:"byline,omitempty"`
+	Excerpt       string `json:"excerpt,omitempty"`
+	Language      string `json:"language,omitempty"`
+	SiteName      string `json:"siteName,omitempty"`
+	Readerable    bool   `json:"readerable"`
+	PublishedTime string `json:"publishedTime,omitempty"`
+	ModifiedTime  string `json:"modifiedTime,omitempty"`
 }
 
 func Test_parser(t *testing.T) {
@@ -94,6 +97,14 @@ func Test_parser(t *testing.T) {
 
 			if metadata.Language != article.Language {
 				t1.Errorf("language, want %q got %q\n", metadata.Language, article.Language)
+			}
+
+			if !timesAreEqual(metadata.PublishedTime, article.PublishedTime) {
+				t1.Errorf("date published, want %q got %q\n", metadata.PublishedTime, article.PublishedTime)
+			}
+
+			if !timesAreEqual(metadata.ModifiedTime, article.ModifiedTime) {
+				t1.Errorf("date modified, want %q got %q\n", metadata.ModifiedTime, article.ModifiedTime)
 			}
 		})
 	}
@@ -251,4 +262,17 @@ func getNodeExcerpt(node *html.Node) string {
 		return outer
 	}
 	return outer[:120]
+}
+
+func timesAreEqual(metadataTimeString string, parsedTime *time.Time) bool {
+	if metadataTimeString == "" && parsedTime == nil {
+		return true
+	}
+
+	if metadataTimeString == "" || parsedTime == nil {
+		return false
+	}
+
+	metadataTime := getParsedDate(metadataTimeString)
+	return metadataTime.Equal(*parsedTime)
 }

--- a/test-pages/aktualne/expected-metadata.json
+++ b/test-pages/aktualne/expected-metadata.json
@@ -4,5 +4,7 @@
     "excerpt": "Zázrak jedné sezony? West Ham United dává pochybovačům stále pádnější odpovědi.",
     "language": "cs",
     "siteName": "Aktuálně.cz",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2021-11-01T10:52:50+01:00",
+    "modifiedTime": "2021-11-01T12:34:23+01:00"
 }

--- a/test-pages/breitbart/expected-metadata.json
+++ b/test-pages/breitbart/expected-metadata.json
@@ -4,5 +4,7 @@
     "excerpt": "Snopes fact checker and staff writer David Emery posted to Twitter asking if there were “any un-angry Trump supporters?”",
     "language": "en",
     "siteName": "Breitbart",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2016-12-22T10:43:37-08:00",
+    "modifiedTime": "2016-12-22T18:59:12-08:00"
 }

--- a/test-pages/bug-1255978/expected-metadata.json
+++ b/test-pages/bug-1255978/expected-metadata.json
@@ -3,5 +3,7 @@
     "byline": "Hazel Sheffield",
     "excerpt": "Most people go to hotels for the pleasure of sleeping in a giant bed with clean white sheets and waking up to fresh towels in the morning. But those towels and sheets might not be as clean as they look, according to the hotel bosses that responded to an online thread about the things hotel owners don’t want you to know.",
     "siteName": "The Independent",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2015-09-17T16:57:43+01:00",
+    "modifiedTime": "2016-05-08T10:11:51+01:00"
 }

--- a/test-pages/folha/expected-metadata.json
+++ b/test-pages/folha/expected-metadata.json
@@ -4,5 +4,7 @@
     "excerpt": "Na ocasião, técnico do Corinthians entregou réplica do troféu ao ex-presidente",
     "language": "pt-BR",
     "siteName": "Folha de S.Paulo",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2018-12-21 12:55:00",
+    "modifiedTime": "2018-12-21 12:56:02"
 }

--- a/test-pages/guardian-1/expected-metadata.json
+++ b/test-pages/guardian-1/expected-metadata.json
@@ -4,5 +4,7 @@
     "excerpt": "New Zealand’s whale whisperers worry that manmade changes in the ocean are behind the spike in beachings",
     "language": "en",
     "siteName": "the Guardian",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2019-01-03T07:00:02.000Z",
+    "modifiedTime": "2019-01-16T11:16:23.000Z"
 }

--- a/test-pages/iab-1/expected-metadata.json
+++ b/test-pages/iab-1/expected-metadata.json
@@ -4,5 +4,7 @@
     "excerpt": "We messed up. As technologists, tasked with delivering content and services to users, we lost track of the user experience. Twenty years ago we saw an explosion of websites, built by developers around the world, providing all forms of content. This was the beginning of an age of enlightenment, the intersection of content and technology. … Continued",
     "language": "en-US",
     "siteName": "IAB",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2015-10-15T08:00:26+00:00",
+    "modifiedTime": "2015-10-16T12:56:08+00:00"
 }

--- a/test-pages/keep-images/expected-metadata.json
+++ b/test-pages/keep-images/expected-metadata.json
@@ -3,5 +3,6 @@
     "byline": "Joseph Cox",
     "excerpt": "Welcome to DoctorX’s Barcelona lab, where the drugs you bought online are tested for safety and purity. No questions ask…",
     "siteName": "Medium",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2015-03-27T13:07:55.096Z"
 }

--- a/test-pages/lazy-image-1/expected-metadata.json
+++ b/test-pages/lazy-image-1/expected-metadata.json
@@ -4,5 +4,6 @@
     "excerpt": "How to run a CPU profiling with Node.js on your production in real-time and without interruption of service.",
     "language": "en",
     "siteName": "Voodoo Engineering",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2019-10-18T17:23:34.816Z"
 }

--- a/test-pages/liberation-1/expected-metadata.json
+++ b/test-pages/liberation-1/expected-metadata.json
@@ -4,5 +4,7 @@
     "excerpt": "Laurent Fabius a accueilli jeudi matin à Roissy un premier avion spécial ramenant des rescapés.",
     "language": "fr",
     "siteName": "Libération.fr",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2015-04-30T07:19:58",
+    "modifiedTime": "2015-04-30T07:38:17"
 }

--- a/test-pages/medium-1/expected-metadata.json
+++ b/test-pages/medium-1/expected-metadata.json
@@ -3,5 +3,6 @@
     "byline": "Pippin Lee",
     "excerpt": "We pushed out the first version of the Open Journalism site in January. Here’s what we’ve learned about student journali…",
     "siteName": "Medium",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2015-03-17T16:27:40.294Z"
 }

--- a/test-pages/medium-2/expected-metadata.json
+++ b/test-pages/medium-2/expected-metadata.json
@@ -3,5 +3,6 @@
     "byline": "Courtney Kirchoff",
     "excerpt": "In defense of the word “literally” and why you or someone you know should stop misusing the word, lest they drive us fig…",
     "siteName": "Medium",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2015-02-24T19:56:33.374Z"
 }

--- a/test-pages/medium-3/expected-metadata.json
+++ b/test-pages/medium-3/expected-metadata.json
@@ -4,5 +4,6 @@
     "excerpt": "(EDIT: removed the link to Samantha’s post, because the arments and the grubers and the rest of The Deck Clique got what they wanted: a non-proper person driven off the internet lightly capped with a…",
     "language": "en",
     "siteName": "Medium",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2015-12-11T14:28:34.438Z"
 }

--- a/test-pages/seattletimes-1/expected-metadata.json
+++ b/test-pages/seattletimes-1/expected-metadata.json
@@ -4,5 +4,7 @@
     "excerpt": "The story of Whole Foods’ halibut deal opens a window into Amazon’s grocery strategy and draws a line from a Seattle industry with roots in the 19th century to the dominant economic force of the 21st.",
     "language": "en-US",
     "siteName": "The Seattle Times",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2019-04-28 06:01:07",
+    "modifiedTime": "2019-04-29 15:33:39"
 }

--- a/test-pages/topicseed-1/expected-metadata.json
+++ b/test-pages/topicseed-1/expected-metadata.json
@@ -2,5 +2,7 @@
     "title": "Content Depth — Write Comprehensively About Your Core Topics",
     "excerpt": "Content writers and marketers find it hard to write a lot of content about a very specific topic. They lose a lot of points on their content depth because they would rather focus on pushing thin content about plenty of topics.",
     "siteName": "topicseed",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2018-06-12T23:00:00.000Z",
+    "modifiedTime": "2018-06-12T23:00:00.000Z"
 }

--- a/test-pages/videos-1/expected-metadata.json
+++ b/test-pages/videos-1/expected-metadata.json
@@ -3,5 +3,7 @@
     "byline": "Alissa Wilkinson",
     "excerpt": "It was an extraordinary year for movies.",
     "siteName": "Vox",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2017-12-15T08:50:02-05:00",
+    "modifiedTime": "2018-07-24T14:15:58-04:00"
 }

--- a/test-pages/videos-2/expected-metadata.json
+++ b/test-pages/videos-2/expected-metadata.json
@@ -4,5 +4,7 @@
     "excerpt": "Séries, documentaires, programmes jeunesse… Retrouvez les recommandations de Libération pour savoir quoi regarder sur vos écrans cette semaine. Pour dépasser...",
     "language": "fr",
     "siteName": "Libération",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2017-11-24T18:42:20",
+    "modifiedTime": "2017-11-24T18:42:20"
 }

--- a/test-pages/wikia/expected-metadata.json
+++ b/test-pages/wikia/expected-metadata.json
@@ -4,5 +4,6 @@
     "excerpt": "As a 40th birthday present to the Star Wars Saga and its fans, Lucasfilm could re-release the original versions of the original trilogy films.",
     "language": "en",
     "siteName": "Fandom powered by Wikia",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2017-02-23T17:18:13-08:00"
 }

--- a/test-pages/wordpress/expected-metadata.json
+++ b/test-pages/wordpress/expected-metadata.json
@@ -3,5 +3,7 @@
     "excerpt": "Stack Overflow published its analysis of 2017 hiring trends based on the targeting options employers selected when posting to Stack Overflow Jobs. The report, which compares data from 200 companies…",
     "language": "en-US",
     "siteName": "WordPress Tavern",
-    "readerable": true
+    "readerable": true,
+    "publishedTime": "2017-03-09T23:16:02+00:00",
+    "modifiedTime": "2017-03-09T23:16:02+00:00"
 }


### PR DESCRIPTION
To build on #37 and #20, I've done the following:

- Added `PublishedTime` and `ModifiedTime` to Article as `*time.Time` to account for when they're absent.
- Improved `getParsedDate(dateStr string) *time.Time` so that more date string formats get parsed correctly.
- Fixed `rxPropertyPattern` and `rxNamePattern` to match `article:published|modified_time` (the easiest way to parse such dates).
- Fixed failing tests with one or both <meta> in their source.html. I also had to create a function to test equality between the dates.

All tests are passing, so hope for a merge soon.