### PR TITLE
feat: allow to use custom request modifiers

### DIFF
--- a/readability.go
+++ b/readability.go
@@ -33,9 +33,11 @@ func FromDocument(doc *html.Node, pageURL *nurl.URL) (Article, error) {
 	return parser.ParseDocument(doc, pageURL)
 }
 
+type RequestWith func(r *http.Request)
+
 // FromURL fetch the web page from specified url then parses the response to find
 // the readable content.
-func FromURL(pageURL string, timeout time.Duration) (Article, error) {
+func FromURL(pageURL string, timeout time.Duration, requestModifiers ...RequestWith) (Article, error) {
 	// Make sure URL is valid
 	parsedURL, err := nurl.ParseRequestURI(pageURL)
 	if err != nil {
@@ -44,7 +46,14 @@ func FromURL(pageURL string, timeout time.Duration) (Article, error) {
 
 	// Fetch page from URL
 	client := &http.Client{Timeout: timeout}
-	resp, err := client.Get(pageURL)
+	req, err := http.NewRequest("GET", pageURL, nil)
+	for _, modifer := range requestModifiers {
+		modifer(req)
+	}
+	if err != nil {
+		return Article{}, fmt.Errorf("failed to fetch the page: %v", err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return Article{}, fmt.Errorf("failed to fetch the page: %v", err)
 	}


### PR DESCRIPTION
This pull request introduces a new feature to allow modification of HTTP requests in the `FromURL` function in the `readability.go` file. The changes include adding a new type and modifying the function signature and implementation to support custom request modifiers.

Key changes:

* Added a new type `RequestWith` to represent a function that modifies an `http.Request`.
* Modified the `FromURL` function signature to accept variadic `RequestWith` arguments, allowing callers to pass custom request modifiers.
* Updated the `FromURL` function implementation to create an `http.Request` and apply the provided modifiers before executing the request with the `http.Client`.

Closes https://github.com/go-shiori/go-readability/issues/52