### PR TITLE
Preserve IDs & class names of unwrapped DIVs

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -890,8 +890,16 @@ func (ps *Parser) grabArticle() *html.Node {
 				// the scoring algorithm with DIVs with are, in
 				// practice, paragraphs.
 				if ps.hasSingleTagInsideElement(node, "p") && ps.getLinkDensity(node) < 0.25 {
+					divID := dom.ID(node)
+					divClassName := dom.ClassName(node)
 					newNode := dom.Children(node)[0]
 					node, _ = dom.ReplaceChild(node.Parent, newNode, node)
+					if divID != "" && dom.ID(node) == "" {
+						dom.SetAttribute(node, "id", divID)
+					}
+					if divClassName != "" && dom.ClassName(node) == "" {
+						dom.SetAttribute(node, "class", divClassName)
+					}
 					elementsToScore = append(elementsToScore, node)
 				} else if !ps.hasChildBlockElement(node) {
 					ps.setNodeTag(node, "p")

--- a/test-pages/gmw/expected.html
+++ b/test-pages/gmw/expected.html
@@ -51,7 +51,7 @@
                     <a href="http://www.gmw.cn" target="_blank"><img src="https://img.gmw.cn/pic/content_logo.png" title="返回光明网首页"/></a>
                 </p>
                 
-                <p>[责任编辑:肖春芳]</p>
+                <p id="contentLiability">[责任编辑:肖春芳]</p>
                 
                 
             </div></div>

--- a/test-pages/lazy-image-1/expected.html
+++ b/test-pages/lazy-image-1/expected.html
@@ -38,7 +38,7 @@
                                         (for more details about V8 and its garbage collector you can read my previous article <a target="_blank" rel="noopener" href="http://fakehost/voodoo-engineering/nodejs-internals-v8-garbage-collector-a6eca82540ec">here</a>)
                                     </p>
                                     <blockquote>
-                                        <p>
+                                        <p id="6f9a">
                                                 Stay focused on the CPU!
                                             </p>
                                     </blockquote>
@@ -61,7 +61,7 @@
                                         CPU profiling: what’s the difference with CPU monitoring?
                                     </h2>
                                     <blockquote>
-                                        <p>
+                                        <p id="19fb">
                                                 “Most commonly, profiling information serves to aid program optimization. Profiling is achieved by instrumenting either the program source code or its binary executable form using a tool called a profiler”
                                             </p>
                                     </blockquote>


### PR DESCRIPTION
I've discovered this when I was debugging why the table of contents of [a very large document](https://koreader.rocks/user_guide/) didn't work anymore after being processed by go-readability.

Some documents use DIVs instead of P elements (such as in this case), or they wrap a single P element (such as on `http://mobile.slate.com`, according to existing code comments). In both of these cases, readability will replace the DIV with P, but in the process the ID of the original DIV would be discarded. This would break the table of contents if it relied on that ID to link to that section.

This change makes it so that the "id" and "class" attributes are preserved when a DIV has been swapped out with a P. The classes would later get stripped per readability default setting, but just in case the user opted into preserving them, they are kept too so no information gets lost when swapping out elements.

I haven't felt I should add new test cases because some existing tests could be updated to reflect the new behavior. 