### PR TITLE
Optimize logging HTML nodes by skipping costly compute when Debug is off

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -976,7 +976,7 @@ func (ps *Parser) grabArticle() *html.Node {
 		for i := 0; i < len(candidates); i++ {
 			candidate := candidates[i]
 			candidateScore := ps.getContentScore(candidate) * (1 - ps.getLinkDensity(candidate))
-			ps.logf("candidate %q with score: %f\n", dom.OuterHTML(candidate), candidateScore)
+			ps.logf("candidate %q with score: %f\n", inspectNode(candidate), candidateScore)
 			ps.setContentScore(candidate, candidateScore)
 		}
 
@@ -1009,7 +1009,7 @@ func (ps *Parser) grabArticle() *html.Node {
 			// Move everything (not just elements, also text nodes etc.)
 			// into the container so we even include text directly in the body:
 			for page.FirstChild != nil {
-				ps.logf("moving child out: %q\n", dom.OuterHTML(page.FirstChild))
+				ps.logf("moving child out: %q\n", inspectNode(page.FirstChild))
 				dom.AppendChild(topCandidate, page.FirstChild)
 			}
 
@@ -2124,7 +2124,7 @@ func (ps *Parser) cleanHeaders(e *html.Node) {
 	ps.removeNodes(headingNodes, func(node *html.Node) bool {
 		// Removing header with low class weight
 		if ps.getClassWeight(node) < 0 {
-			ps.logf("removing header with low class weight: %q\n", dom.OuterHTML(node))
+			ps.logf("removing header with low class weight: %q\n", inspectNode(node))
 			return true
 		}
 		return false
@@ -2302,6 +2302,19 @@ func (ps *Parser) logf(format string, args ...interface{}) {
 	if ps.Debug {
 		log.Printf(format, args...)
 	}
+}
+
+// inspectNode wraps a HTML node to use with printf-style functions.
+func inspectNode(node *html.Node) fmt.Stringer {
+	return &inspectedNode{node}
+}
+
+type inspectedNode struct {
+	node *html.Node
+}
+
+func (n *inspectedNode) String() string {
+	return dom.OuterHTML(n.node)
 }
 
 // UNUSED CODES


### PR DESCRIPTION
By default, `Parser.Debug` property is false and writing to the logger is disabled. However, invocations of `Parser.logf()` would still happen regardless of the Debug property, which included arguments that were the result of `dom.OuterHTML()` invocations.

OuterHTML is costly because it serializes the entire DOM into a string. For large HTML documents, this would cause unnecessary overhead in default mode of operation where logging is disabled.

My benchmark environment:

    goos: darwin
    goarch: arm64
    cpu: Apple M1

Benchmark results for parsing `test-pages/wikipedia-2/source.html`:

variant | times | ns/op           | Bytes/op          | allocs/op
-------|-------|------------------|-----------------|------------------
before | 25    | 46,007,988  | 73,742,416  | 201,175 
after  | 30    | 38,579,637 | 59,611,452  | 199,875 

The memory reduction for a very large HTML document was significant, at no change to readability functionality.