### PR TITLE
Fix extracting images from figures on Medium

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -588,7 +588,7 @@ func (ps *Parser) prepArticle(articleContent *html.Node) {
 				switch node.Data {
 				// At this point, nasty iframes have been removed, only
 				// remain embedded video ones.
-				case "img", "embed", "object", "iframe":
+				case "img", "picture", "embed", "object", "iframe":
 					return true
 				}
 			} else if node.Type == html.TextNode {

--- a/test-pages/keep-images-2/expected-metadata.json
+++ b/test-pages/keep-images-2/expected-metadata.json
@@ -1,0 +1,5 @@
+{
+    "excerpt": "The Medium publishing engine wraps PICTURE elements within a DIV within a FIGURE:",
+    "language": "en",
+    "readerable": true
+}

--- a/test-pages/keep-images-2/expected.html
+++ b/test-pages/keep-images-2/expected.html
@@ -2,7 +2,13 @@
     <h2>The image-stripping bug</h2>
     <p>The Medium publishing engine wraps PICTURE elements within a DIV within a FIGURE:</p>
     <figure>
-      
+      <p>
+        <picture>
+          <source srcset="http://fakehost/test/photo.avif" type="image/avif"/>
+          <source srcset="http://fakehost/test/photo.webp" type="image/webp"/>
+          
+        </picture>
+      </p>
     </figure>
     <p>However, after this is processed with readability, the FIGURE element will be empty.</p>
     <p>Note that the IMG element does not have the &#34;src&#34; attribute. It seems that the src is populated by client-side JavaScript based on the information in SOURCE elements. Readability removes such IMG elements in &#34;unwrapNoscriptImages&#34;.</p>

--- a/test-pages/keep-images-2/expected.html
+++ b/test-pages/keep-images-2/expected.html
@@ -1,0 +1,11 @@
+<div id="readability-page-1" class="page"><article>
+    <h2>The image-stripping bug</h2>
+    <p>The Medium publishing engine wraps PICTURE elements within a DIV within a FIGURE:</p>
+    <figure>
+      
+    </figure>
+    <p>However, after this is processed with readability, the FIGURE element will be empty.</p>
+    <p>Note that the IMG element does not have the &#34;src&#34; attribute. It seems that the src is populated by client-side JavaScript based on the information in SOURCE elements. Readability removes such IMG elements in &#34;unwrapNoscriptImages&#34;.</p>
+    <p>Then, the DIV is converted to P by logic in code commented with &#34;Turn all divs that don&#39;t have children block level lements into p&#34;.</p>
+    <p>Finally, because the new P is considered empty (it has no text nor images), it is removed by the &#34;Remove extra paragraphs&#34; logic.</p>
+  </article></div>

--- a/test-pages/keep-images-2/source.html
+++ b/test-pages/keep-images-2/source.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+
+<body>
+  <article>
+    <h1>The image-stripping bug</h1>
+    <p>The Medium publishing engine wraps PICTURE elements within a DIV within a FIGURE:</p>
+    <figure>
+      <div>
+        <picture>
+          <source srcset="photo.avif" type="image/avif" />
+          <source srcset="photo.webp" type="image/webp" />
+          <img alt="photo" />
+        </picture>
+      </div>
+    </figure>
+    <p>However, after this is processed with readability, the FIGURE element will be empty.</p>
+    <p>Note that the IMG element does not have the "src" attribute. It seems that the src is populated by client-side JavaScript based on the information in SOURCE elements. Readability removes such IMG elements in "unwrapNoscriptImages".</p>
+    <p>Then, the DIV is converted to P by logic in code commented with "Turn all divs that don't have children block level lements into p".</p>
+    <p>Finally, because the new P is considered empty (it has no text nor images), it is removed by the "Remove extra paragraphs" logic.</p>
+  </article>
+</body>
+
+</html>


### PR DESCRIPTION
This markup from Medium would result in an empty `<figure></figure>` element after making readable:

```html
<figure>
  <div>
    <picture>
      <source srcset="photo.avif" type="image/avif" />
      <source srcset="photo.webp" type="image/webp" />
      <img alt="photo" />
    </picture>
  </div>
</figure>
```

1. Readability removes the `img` element with an empty src;
2. The `div` is converted to a `p`;
3. The new `p` was considered empty because it has no `img` element, and thus it was stripped away.

Now a `picture` element is also considered in addition to `img`.

Fixes https://github.com/go-shiori/go-readability/issues/76

Bonus: optimized "remove extra paragraph" logic to reduce allocations. Ref. https://github.com/go-shiori/go-readability/pull/99